### PR TITLE
添加 WPF 示例 + 为 Evaluate 添加容错

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 obj/
 bin/
 /.vs
+Live2DCubismCore.dll

--- a/Live2DCSharpSDK.Framework/Physics/CubismPhysics.cs
+++ b/Live2DCSharpSDK.Framework/Physics/CubismPhysics.cs
@@ -482,6 +482,10 @@ public class CubismPhysics
             for (settingIndex = 0; settingIndex < _physicsRig.SubRigCount; ++settingIndex)
             {
                 currentSetting = _physicsRig.Settings[settingIndex];
+                if(currentSetting.BaseOutputIndex >= _physicsRig.Outputs.Length)
+                {
+                    continue;
+                }
                 currentOutputs = _physicsRig.Outputs[currentSetting.BaseOutputIndex];
                 for (i = 0; i < currentSetting.OutputCount; ++i)
                 {

--- a/Live2DCSharpSDK.OpenTK/Live2DCSharpSDK.WPF.csproj
+++ b/Live2DCSharpSDK.OpenTK/Live2DCSharpSDK.WPF.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTK" Version="4.8.2" />
+    <PackageReference Include="OpenTK.GLWpfControl" Version="4.2.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Live2DCSharpSDK.App\Live2DCSharpSDK.App.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Live2DCubismCore.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Live2DCSharpSDK.WPF/App.xaml
+++ b/Live2DCSharpSDK.WPF/App.xaml
@@ -1,0 +1,9 @@
+﻿<Application x:Class="Live2DCSharpSDK.WPF.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:Live2DCSharpSDK.WPF"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+         
+    </Application.Resources>
+</Application>

--- a/Live2DCSharpSDK.WPF/App.xaml.cs
+++ b/Live2DCSharpSDK.WPF/App.xaml.cs
@@ -1,0 +1,14 @@
+﻿using System.Configuration;
+using System.Data;
+using System.Windows;
+
+namespace Live2DCSharpSDK.WPF
+{
+    /// <summary>
+    /// Interaction logic for App.xaml
+    /// </summary>
+    public partial class App : Application
+    {
+    }
+
+}

--- a/Live2DCSharpSDK.WPF/AssemblyInfo.cs
+++ b/Live2DCSharpSDK.WPF/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
+                                                //(used if a resource is not found in the page,
+                                                // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly   //where the generic resource dictionary is located
+                                                //(used if a resource is not found in the page,
+                                                // app, or any theme specific resource dictionaries)
+)]

--- a/Live2DCSharpSDK.WPF/Live2DCSharpSDK.WPF.csproj
+++ b/Live2DCSharpSDK.WPF/Live2DCSharpSDK.WPF.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTK" Version="4.8.2" />
+    <PackageReference Include="OpenTK.GLWpfControl" Version="4.2.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Live2DCSharpSDK.App\Live2DCSharpSDK.App.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Live2DCubismCore.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Live2DCSharpSDK.WPF/Live2DCSharpSDK.WPF.user
+++ b/Live2DCSharpSDK.WPF/Live2DCSharpSDK.WPF.user
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+  <ItemGroup>
+    <ApplicationDefinition Update="App.xaml">
+      <SubType>Designer</SubType>
+    </ApplicationDefinition>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="MainWindow.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="Live2DCubismCore.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/Live2DCSharpSDK.WPF/MainWindow.xaml
+++ b/Live2DCSharpSDK.WPF/MainWindow.xaml
@@ -1,0 +1,15 @@
+﻿<Window x:Class="Live2DCSharpSDK.WPF.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Live2DCSharpSDK.WPF"
+        mc:Ignorable="d"
+        Title="MainWindow" Height="450" Width="800">
+    <Grid>
+        <Grid>
+            <Border x:Name="BorderOpenTK">
+            </Border>
+        </Grid>
+    </Grid>
+</Window>

--- a/Live2DCSharpSDK.WPF/MainWindow.xaml.cs
+++ b/Live2DCSharpSDK.WPF/MainWindow.xaml.cs
@@ -1,0 +1,80 @@
+﻿using OpenTK.Wpf;
+using System;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using OpenTK.Graphics.OpenGL4;
+using Live2DCSharpSDK.App;
+using System.Windows.Threading;
+using System.Diagnostics;
+using OpenTK.Mathematics;
+
+namespace Live2DCSharpSDK.WPF
+{
+    /// <summary>
+    /// Interaction logic for MainWindow.xaml
+    /// </summary>
+    public partial class MainWindow : Window
+    {
+        GLWpfControl GLControl;
+        private LAppDelegate lapp;
+        private const float UpdateTime = 1f / 60f; // 60 FPS
+
+        public MainWindow()
+        {
+            InitializeComponent();
+            GLControl = new();
+
+            GLControl.Loaded += GLControl_Loaded;
+            GLControl.SizeChanged += GLControl_Resized;
+
+            BorderOpenTK.Child = GLControl;
+
+            CompositionTarget.Rendering += CompositionTarget_Rendering;
+
+        }
+        LAppModel model;
+        private void GLControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            var settings = new GLWpfControlSettings
+            {
+                MajorVersion = 3,
+                MinorVersion = 3
+            };
+            GLControl.Start(settings);
+            lapp = new(new OpenTKWPFApi(GLControl), Console.WriteLine)
+            {
+                BGColor = new(0, 1, 0, 1)
+            };
+
+            var model = lapp.Live2dManager.LoadModel("F:\\live2d\\Resources\\Mao", "Mao");
+            //model = lapp.Live2dManager.LoadModel("F:\\Downloads\\haru_greeter_pro_jp\\haru_greeter_pro_jp\\runtime", "haru_greeter_t05");
+        }
+        private void CompositionTarget_Rendering(object? sender, EventArgs e)
+        {
+            if (lapp == null)
+                return;
+            lapp.Run(UpdateTime);
+            var code = GL.GetError();
+            if (code != ErrorCode.NoError)
+            {
+                throw new Exception(code.ToString());
+            }
+        }
+
+        private void GLControl_Resized(object sender, SizeChangedEventArgs e)
+        {
+            if (lapp == null)
+                return;
+            lapp.Resize();
+            GL.Viewport(0, 0, (int)GLControl.ActualWidth, (int)GLControl.ActualHeight);
+        }
+    }
+}

--- a/Live2DCSharpSDK.WPF/MainWindow.xaml.cs
+++ b/Live2DCSharpSDK.WPF/MainWindow.xaml.cs
@@ -25,24 +25,17 @@ namespace Live2DCSharpSDK.WPF
     {
         GLWpfControl GLControl;
         private LAppDelegate lapp;
-        private const float UpdateTime = 1f / 60f; // 60 FPS
 
         public MainWindow()
         {
             InitializeComponent();
             GLControl = new();
 
-            GLControl.Loaded += GLControl_Loaded;
             GLControl.SizeChanged += GLControl_Resized;
-
+            GLControl.Render += GLControl_Render;
             BorderOpenTK.Child = GLControl;
+            //CompositionTarget.Rendering += CompositionTarget_Rendering;
 
-            CompositionTarget.Rendering += CompositionTarget_Rendering;
-
-        }
-        LAppModel model;
-        private void GLControl_Loaded(object sender, RoutedEventArgs e)
-        {
             var settings = new GLWpfControlSettings
             {
                 MajorVersion = 3,
@@ -53,21 +46,18 @@ namespace Live2DCSharpSDK.WPF
             {
                 BGColor = new(0, 1, 0, 1)
             };
-
             var model = lapp.Live2dManager.LoadModel("F:\\live2d\\Resources\\Mao", "Mao");
             //model = lapp.Live2dManager.LoadModel("F:\\Downloads\\haru_greeter_pro_jp\\haru_greeter_pro_jp\\runtime", "haru_greeter_t05");
         }
-        private void CompositionTarget_Rendering(object? sender, EventArgs e)
+
+        private void GLControl_Render(TimeSpan obj)
         {
-            if (lapp == null)
-                return;
-            lapp.Run(UpdateTime);
-            var code = GL.GetError();
-            if (code != ErrorCode.NoError)
-            {
-                throw new Exception(code.ToString());
-            }
+            GL.ClearColor(Color4.Blue);
+            GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
+            lapp.Run((float)obj.TotalSeconds);
         }
+
+        LAppModel model;
 
         private void GLControl_Resized(object sender, SizeChangedEventArgs e)
         {

--- a/Live2DCSharpSDK.WPF/OpenTKWPFApi.cs
+++ b/Live2DCSharpSDK.WPF/OpenTKWPFApi.cs
@@ -1,0 +1,328 @@
+﻿using OpenTK.Windowing.Desktop;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenTK.Graphics.OpenGL4;
+using Live2DCSharpSDK.Framework.Rendering.OpenGL;
+using OpenTK.Wpf;
+using System.Windows.Controls;
+
+namespace Live2DCSharpSDK.WPF
+{
+    public class OpenTKWPFApi : OpenGLApi
+    {
+        private readonly GLWpfControl Window;
+
+        public override bool IsES2 => false;
+
+        public override bool IsPhoneES2 => false;
+
+        public override bool AlwaysClear => false;
+
+        public OpenTKWPFApi(GLWpfControl window)
+        {
+            Window = window;
+        }
+
+        public override void GetWindowSize(out int w, out int h)
+        {
+            w = (int)Window.ActualWidth;
+            h = (int)Window.ActualHeight;
+        }
+
+        public override void ActiveTexture(int bit)
+        {
+            GL.ActiveTexture((TextureUnit)bit);
+        }
+
+        public override void AttachShader(int a, int b)
+        {
+            GL.AttachShader(a, b);
+        }
+
+        public override void BindBuffer(int bit, int index)
+        {
+            GL.BindBuffer((BufferTarget)bit, index);
+        }
+
+        public override void BindFramebuffer(int type, int data)
+        {
+            GL.BindFramebuffer((FramebufferTarget)type, data);
+        }
+
+        public override void BindTexture(int bit, int index)
+        {
+            GL.BindTexture((TextureTarget)bit, index);
+        }
+
+        public override void BindVertexArrayOES(int data)
+        {
+            //TODO ES2
+            GL.BindVertexArray(data);
+        }
+
+        public override void BlendFunc(int a, int b)
+        {
+            GL.BlendFunc((BlendingFactor)a, (BlendingFactor)b);
+        }
+
+        public override void BlendFuncSeparate(int a, int b, int c, int d)
+        {
+            GL.BlendFuncSeparate((BlendingFactorSrc)a, (BlendingFactorDest)b, (BlendingFactorSrc)c, (BlendingFactorDest)d);
+        }
+
+        public override void Clear(int bit)
+        {
+            GL.Clear((ClearBufferMask)bit);
+        }
+
+        public override void ClearColor(float r, float g, float b, float a)
+        {
+            GL.ClearColor(r, g, b, a);
+        }
+
+        public override void ClearDepthf(float data)
+        {
+            GL.ClearDepth(data);
+        }
+
+        public override void ColorMask(bool a, bool b, bool c, bool d)
+        {
+            GL.ColorMask(a, b, c, d);
+        }
+
+        public override void CompileShader(int index)
+        {
+            GL.CompileShader(index);
+        }
+
+        public override int CreateProgram()
+        {
+            return GL.CreateProgram();
+        }
+
+        public override int CreateShader(int type)
+        {
+            return GL.CreateShader((ShaderType)type);
+        }
+
+        public override void DeleteFramebuffer(int data)
+        {
+            GL.DeleteFramebuffer(data);
+        }
+
+        public override void DeleteProgram(int index)
+        {
+            GL.DeleteProgram(index);
+        }
+
+        public override void DeleteShader(int index)
+        {
+            GL.DeleteShader(index);
+        }
+
+        public override void DeleteTexture(int data)
+        {
+            GL.DeleteTexture(data);
+        }
+
+        public override void DetachShader(int index, int data)
+        {
+            GL.DetachShader(index, data);
+        }
+
+        public override void Disable(int bit)
+        {
+            GL.Disable((EnableCap)bit);
+        }
+
+        public override void DisableVertexAttribArray(int index)
+        {
+            GL.DisableVertexAttribArray(index);
+        }
+
+        public override unsafe void DrawElements(int type, int count, int type1, nint arry)
+        {
+            GL.DrawElements((PrimitiveType)type, count, (DrawElementsType)type1, (int)arry);
+        }
+
+        public override void Enable(int bit)
+        {
+            GL.Enable((EnableCap)bit);
+        }
+
+        public override void EnableVertexAttribArray(int index)
+        {
+            GL.EnableVertexAttribArray(index);
+        }
+
+        public override void FramebufferTexture2D(int a, int b, int c, int buff, int offset)
+        {
+            GL.FramebufferTexture2D((FramebufferTarget)a, (FramebufferAttachment)b,
+                (TextureTarget)c, buff, offset);
+        }
+
+        public override void FrontFace(int data)
+        {
+            GL.FrontFace((FrontFaceDirection)data);
+        }
+
+        public override void GenerateMipmap(int a)
+        {
+            GL.GenerateMipmap((GenerateMipmapTarget)a);
+        }
+
+        public override int GenFramebuffer()
+        {
+            return GL.GenFramebuffer();
+        }
+
+        public override int GenTexture()
+        {
+            return GL.GenTexture();
+        }
+
+        public override int GetAttribLocation(int index, string attr)
+        {
+            return GL.GetAttribLocation(index, attr);
+        }
+
+        public override void GetBooleanv(int bit, bool[] data)
+        {
+            GL.GetBoolean((GetPName)bit, data);
+        }
+
+        public override void GetIntegerv(int bit, out int data)
+        {
+            GL.GetInteger((GetPName)bit, out data);
+        }
+
+        public override void GetIntegerv(int bit, int[] data)
+        {
+            GL.GetInteger((GetPName)bit, data);
+        }
+
+        public override void GetProgramInfoLog(int index, out string log)
+        {
+            GL.GetProgramInfoLog(index, out log);
+        }
+
+        public override unsafe void GetProgramiv(int index, int type, int* length)
+        {
+            GL.GetProgram(index, (GetProgramParameterName)type, length);
+        }
+
+        public override void GetShaderInfoLog(int index, out string log)
+        {
+            GL.GetShaderInfoLog(index, out log);
+        }
+
+        public override unsafe void GetShaderiv(int index, int type, int* length)
+        {
+            GL.GetShader(index, (ShaderParameter)type, length);
+        }
+
+        public override int GetUniformLocation(int index, string uni)
+        {
+            return GL.GetUniformLocation(index, uni);
+        }
+
+        public override unsafe void GetVertexAttribiv(int index, int bit, out int data)
+        {
+            GL.GetVertexAttrib(index, (VertexAttribParameter)bit, out data);
+        }
+
+        public override bool IsEnabled(int bit)
+        {
+            return GL.IsEnabled((EnableCap)bit);
+        }
+
+        public override void LinkProgram(int index)
+        {
+            GL.LinkProgram(index);
+        }
+
+        public override void ShaderSource(int a, string source)
+        {
+            GL.ShaderSource(a, source);
+        }
+
+        public override void TexImage2D(int type, int a, int type1, int w, int h, int size, int type2, int type3, nint data)
+        {
+            GL.TexImage2D((TextureTarget)type, a, (PixelInternalFormat)type1, w, h, size, (PixelFormat)type2, (PixelType)type3, data);
+        }
+
+        public override void TexParameterf(int type, int type1, float value)
+        {
+            GL.TexParameter((TextureTarget)type, (TextureParameterName)type1, value);
+        }
+
+        public override void TexParameteri(int a, int b, int c)
+        {
+            GL.TexParameter((TextureTarget)a, (TextureParameterName)b, c);
+        }
+
+        public override void Uniform1i(int index, int data)
+        {
+            GL.Uniform1(index, data);
+        }
+
+        public override void Uniform4f(int index, float a, float b, float c, float d)
+        {
+            GL.Uniform4(index, a, b, c, d);
+        }
+
+        public override void UniformMatrix4fv(int index, int length, bool b, float[] data)
+        {
+            GL.UniformMatrix4(index, length, b, data);
+        }
+
+        public override void UseProgram(int index)
+        {
+            GL.UseProgram(index);
+        }
+
+        public override void ValidateProgram(int index)
+        {
+            GL.ValidateProgram(index);
+        }
+
+        public override unsafe void VertexAttribPointer(int index, int length, int type, bool b, int size, nint arr)
+        {
+            GL.VertexAttribPointer(index, length, (VertexAttribPointerType)type, b, size, arr);
+        }
+
+        public override void Viewport(int x, int y, int w, int h)
+        {
+            GL.Viewport(x, y, w, h);
+        }
+
+        public override int GetError()
+        {
+            return (int)GL.GetError();
+        }
+
+        public override int GenBuffer()
+        {
+            return GL.GenBuffer();
+        }
+
+        public override void BufferData(int type, int v1, nint v2, int type1)
+        {
+            GL.BufferData((BufferTarget)type, v1, v2, (BufferUsageHint)type1);
+        }
+
+        public override int GenVertexArray()
+        {
+            return GL.GenVertexArray();
+        }
+
+        public override void BindVertexArray(int vertexArray)
+        {
+            GL.BindVertexArray(vertexArray);
+        }
+    }
+
+}

--- a/Live2DCSharpSDK.sln
+++ b/Live2DCSharpSDK.sln
@@ -18,6 +18,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Live2DCSharpSDK.WPF", "Live2DCSharpSDK.WPF\Live2DCSharpSDK.WPF.csproj", "{31F12B93-E865-43F0-9967-00733D967F76}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -40,6 +42,10 @@ Global
 		{7A072212-FDAC-46D1-9B78-6D37BB5F57D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7A072212-FDAC-46D1-9B78-6D37BB5F57D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7A072212-FDAC-46D1-9B78-6D37BB5F57D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31F12B93-E865-43F0-9967-00733D967F76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{31F12B93-E865-43F0-9967-00733D967F76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{31F12B93-E865-43F0-9967-00733D967F76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31F12B93-E865-43F0-9967-00733D967F76}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -47,6 +53,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{8107A4BA-F80E-47F7-AF7B-4F9467101E93} = {C1A91469-B605-4DDC-964A-137C82ABEF7B}
 		{7A072212-FDAC-46D1-9B78-6D37BB5F57D1} = {C1A91469-B605-4DDC-964A-137C82ABEF7B}
+		{31F12B93-E865-43F0-9967-00733D967F76} = {C1A91469-B605-4DDC-964A-137C82ABEF7B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {53197E4D-3AAB-4AC2-91AF-DDBB326E65FD}


### PR DESCRIPTION
添加示例 Live2DCSharpSDK.WPF, 在WPF中使用 Live2DCSharpSDK 的案例
为 Evaluate 添加容错, 兼容部分模型

若有不需要的功能或内容可以直接改或者关掉pr都行